### PR TITLE
Rely on railties >= 4.0.0, not ~> 4.0.0

### DIFF
--- a/jvectormap-rails4.gemspec
+++ b/jvectormap-rails4.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.has_rdoc = true
 
-  s.add_dependency 'railties', '~> 4.0.0'
+  s.add_dependency 'railties', '> 4.0.0'
 
   s.require_path = 'lib'
   s.files = Dir["{lib,vendor,tasks}/**/*", "Gemfile", "History.txt", "LICENSE", "README.md", "Rakefile", "jvectormap-rails4.gemspec"]

--- a/jvectormap-rails4.gemspec
+++ b/jvectormap-rails4.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.has_rdoc = true
 
-  s.add_dependency 'railties', '> 4.0.0'
+  s.add_dependency 'railties', '>= 4.0.0'
 
   s.require_path = 'lib'
   s.files = Dir["{lib,vendor,tasks}/**/*", "Gemfile", "History.txt", "LICENSE", "README.md", "Rakefile", "jvectormap-rails4.gemspec"]


### PR DESCRIPTION
The gem locks the railties version at 4.0.0, which makes upgrading to Rails 4.2.1 impossible.  This commit simply changes the line:

``` rails
s.add_dependency 'railties', '~> 4.0.0'
```

to

``` rails
s.add_dependency 'railties', '>= 4.0.0'
```

The gem continues to function quite happily in Rails 4.2.1:

![jvectormap-area-map](https://cloud.githubusercontent.com/assets/2857572/8050112/7d99a0e4-0e2d-11e5-9f74-41f5b1325292.png)
